### PR TITLE
fix(notifications): use native Electron Notification for macOS reliability

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,11 @@ let canClose = process.platform !== 'darwin';
 let mainWindow: BrowserWindow;
 
 const initNotificationListener = () => {
-	ipcMain.on('show-notification', (event, { title, body, icon, data }) => {
+	ipcMain.on('show-notification', (event, payload: { title: string; body: string; icon?: string; data?: unknown }) => {
+		if (!payload || typeof payload.title !== 'string' || typeof payload.body !== 'string') {
+			return;
+		}
+		const { title, body, icon, data } = payload;
 		const notification = new Notification({
 			title,
 			body,

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,13 +1,12 @@
 import { ipcRenderer } from 'electron';
 
 // Send notification to main process (uses native Electron Notification)
-window.addEventListener('showNotification', (e: CustomEvent) => {
-	const { title, body, icon, data } = e.detail;
-	ipcRenderer.send('show-notification', { title, body, icon, data });
+window.addEventListener('showNotification', (e: CustomEvent<{ title: string; body: string; icon?: string; data?: unknown }>) => {
+	ipcRenderer.send('show-notification', e.detail);
 });
 
 // Receive notification click from main process
-ipcRenderer.on('notification-clicked', (_, data) => {
+ipcRenderer.on('notification-clicked', (_, data: unknown) => {
 	const event = new CustomEvent('desktopNotificationClick', { detail: data });
 	window.dispatchEvent(event);
 });

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,35 +1,19 @@
 import { ipcRenderer } from 'electron';
 
+// Send notification to main process (uses native Electron Notification)
 window.addEventListener('showNotification', (e: CustomEvent) => {
-	const { title, body, icon } = e.detail;
-	const notification = sendNotification(title, { body, icon, silent: false });
-	notification.addEventListener('click', () => {
-		const event = new CustomEvent('desktopNotificationClick', { detail: e.detail.data });
-		ipcRenderer.send('respore-window');
-		window.dispatchEvent(event);
-	});
+	const { title, body, icon, data } = e.detail;
+	ipcRenderer.send('show-notification', { title, body, icon, data });
 });
 
+// Receive notification click from main process
+ipcRenderer.on('notification-clicked', (_, data) => {
+	const event = new CustomEvent('desktopNotificationClick', { detail: data });
+	window.dispatchEvent(event);
+});
+
+// Badge count
 window.addEventListener('setBadgeCount', (e: CustomEvent) => {
 	const { count = 0 } = e.detail;
 	ipcRenderer.send('update-badge', count);
 });
-
-const sendNotification = (title: string, body: NotificationOptions) => {
-	if (!('Notification' in window)) {
-		return;
-	}
-	if (Notification.permission === 'granted') {
-		return new Notification(title, body);
-	}
-
-	if (Notification.permission !== 'denied') {
-		Notification.requestPermission().then((permission) => {
-			if (permission === 'granted') {
-				return new Notification(title, body);
-			}
-		});
-	}
-};
-
-Notification.requestPermission();


### PR DESCRIPTION
## Problem
Desktop notifications don't work reliably on macOS, especially on Ventura/Sonoma.

## Root Cause
The previous implementation used Web Notification API in preload.ts:
- Permission state can get lost after app/OS updates
- Async permission flow loses notification references (calling `.addEventListener` on `undefined`)
- Browser context in Electron preload has limitations on macOS

## Solution
Move notification handling to main process using native Electron Notification:
- Uses system-level APIs directly
- More reliable permission handling
- Proper click event handling with window restoration

## Changes
- `src/main.ts`: Add `initNotificationListener()` using `Notification` from electron
- `src/preload.ts`: Simplify to just forward events via IPC
- Bonus: Fix typo `respore-window` → `restore-window` (kept legacy handler for backwards compat)

## Testing
1. Build the app: `yarn build:electron:mac`
2. Install on macOS
3. Trigger a notification from web app
4. Verify notification appears in Notification Center
5. Click notification → app should restore and focus